### PR TITLE
Fix to how data is acquired. 

### DIFF
--- a/DeckCustomization/DeckCustomization.cs
+++ b/DeckCustomization/DeckCustomization.cs
@@ -27,7 +27,7 @@ namespace DeckCustomization
     [BepInDependency("pykess.rounds.plugins.moddingutils", BepInDependency.DependencyFlags.HardDependency)] // utilities for cards and cardbars
     [BepInDependency("pykess.rounds.plugins.cardchoicespawnuniquecardpatch", BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("root.rarity.lib", BepInDependency.DependencyFlags.HardDependency)]
-    [BepInPlugin(ModId, ModName, "0.2.3")]
+    [BepInPlugin(ModId, ModName, "0.2.4")]
     [BepInProcess("Rounds.exe")]
     public class DeckCustomization : BaseUnityPlugin
     {
@@ -116,14 +116,7 @@ namespace DeckCustomization
                 string mod = defaultCardsName;
                 foreach (CardInfo card in allCards)
                 {
-                    if (card.gameObject.GetComponent<CustomCard>() != null)
-                    {
-                        mod = card.gameObject.GetComponent<CustomCard>().GetModName().ToLower();
-                    }
-                    else
-                    {
-                        mod = defaultCardsName;
-                    }
+                    mod = CardManager.cards.Values.First(c => c.cardInfo == card).category;
 
                     // mod
                     ModRaritiesConfig[mod] = Config.Bind(CompatibilityModName, mod, RarityUtils.defaultGeneralRarity, "Relative rarity of " + mod + " cards on a scale of 0 (disabled) to 1 (common)");
@@ -131,13 +124,13 @@ namespace DeckCustomization
                 }
 
                 // cardtheme
-                foreach (CardThemeColor.CardThemeColorType theme in allCards.Select(c => c.colorTheme))
+                foreach (CardThemeColor.CardThemeColorType theme in Enum.GetValues(typeof(CardThemeColor.CardThemeColorType)))
                 {
                     ThemeRaritiesConfig[theme] = Config.Bind(CompatibilityModName, theme.ToString(), RarityUtils.defaultGeneralRarity, $"Relative rarity of {theme} cards on a scale of 0 (disabled) to 1 (common)");
                 }
 
                 // rarity
-                foreach (CardInfo.Rarity r in allCards.Select(c => c.rarity))
+                foreach (CardInfo.Rarity r in Enum.GetValues(typeof(CardInfo.Rarity)))
                 {
                     Rarity rarity = RarityLib.Utils.RarityUtils.GetRarityData(r);
                     RarityRaritiesConfig[rarity.value] = Config.Bind(CompatibilityModName, rarity.name, rarity.relativeRarity, $"Relative rarity of {rarity.name} cards on a scale of 0 (disabled) to 1 (common)");
@@ -146,14 +139,7 @@ namespace DeckCustomization
 
                 foreach (CardInfo card in allCards)
                 {
-                    if (card.gameObject.GetComponent<CustomCard>() != null)
-                    {
-                        mod = card.gameObject.GetComponent<CustomCard>().GetModName().ToLower();
-                    }
-                    else
-                    {
-                        mod = defaultCardsName;
-                    }
+                    mod = CardManager.cards.Values.First(c => c.cardInfo == card).category;
 
                     // mod
                     ModRarities[mod] = ModRaritiesConfig[mod].Value;

--- a/DeckCustomization/DeckCustomization.cs
+++ b/DeckCustomization/DeckCustomization.cs
@@ -27,6 +27,7 @@ namespace DeckCustomization
     [BepInDependency("pykess.rounds.plugins.moddingutils", BepInDependency.DependencyFlags.HardDependency)] // utilities for cards and cardbars
     [BepInDependency("pykess.rounds.plugins.cardchoicespawnuniquecardpatch", BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("root.rarity.lib", BepInDependency.DependencyFlags.HardDependency)]
+    [BepInDependency("root.cardtheme.lib", BepInDependency.DependencyFlags.HardDependency)]
     [BepInPlugin(ModId, ModName, "0.2.4")]
     [BepInProcess("Rounds.exe")]
     public class DeckCustomization : BaseUnityPlugin
@@ -175,12 +176,12 @@ namespace DeckCustomization
                 // sync twice just to be safe
                 for (int i = 0; i<2; i++)
                 {
-                    NetworkingManager.RPC_Others(typeof(DeckCustomization), nameof(SyncSettings), new object[] { BetterMethod, ModRarities.Keys.ToArray(), ModRarities.Values.ToArray(), RarityRarities.Keys.Select(k => (byte)k).ToArray(), RarityRarities.Values.ToArray(), ThemeRarities.Keys.Select(k=>(byte)k).ToArray(), ThemeRarities.Values.ToArray() });
+                    NetworkingManager.RPC_Others(typeof(DeckCustomization), nameof(SyncSettings), new object[] { BetterMethod, ModRarities.Keys.ToArray(), ModRarities.Values.ToArray(), RarityRarities.Keys.Select(k => k.ToString()).ToArray(), RarityRarities.Values.ToArray(), ThemeRarities.Keys.Select(k=>k.ToString()).ToArray(), ThemeRarities.Values.ToArray() });
                 }
             }
         }
         [UnboundRPC]
-        private static void SyncSettings(bool better, string[] mods, float[] modrarities, byte[] rarities, float[] rarityrarities, byte[] themes, float[] themerarities)
+        private static void SyncSettings(bool better, string[] mods, float[] modrarities, string[] rarities, float[] rarityrarities, string[] themes, float[] themerarities)
         {
             //BetterMethod = better;
 
@@ -190,11 +191,11 @@ namespace DeckCustomization
             }
             for (int i = 0; i<rarities.Length; i++)
             {
-                RarityRarities[(CardInfo.Rarity)rarities[i]] = rarityrarities[i];
+                RarityRarities[RarityLib.Utils.RarityUtils.GetRarity(rarities[i])] = rarityrarities[i];
             }
             for (int i = 0; i<themes.Length; i++)
             {
-                ThemeRarities[(CardThemeColor.CardThemeColorType)themes[i]] = themerarities[i];
+                ThemeRarities[CardThemeLib.CardThemeLib.instance.CreateOrGetType(themes[i])] = themerarities[i];
             }
 
         }

--- a/DeckCustomization/FixThemes.cs
+++ b/DeckCustomization/FixThemes.cs
@@ -28,8 +28,10 @@ namespace DeckCustomization
          * 
          * BigBullet -> DestructiveRed
          * BuckShot -> FirepowerYellow
+         * DrillAmmo -> TechWhite
          * Echo -> DefensiveBlue
          * Empower -> FirepowerYellow
+         * ExplosiveBullet -> FirepowerYellow
          * Implode -> MagicPink
          * Saw -> TechWhite
          * Shockwave -> DestructiveRed
@@ -51,10 +53,16 @@ namespace DeckCustomization
                     case "buckshot":
                         card.colorTheme = CardThemeColor.CardThemeColorType.FirepowerYellow;
                         break;
+                    case "drill ammo":
+                        card.colorTheme = CardThemeColor.CardThemeColorType.TechWhite;
+                        break;
                     case "echo":
                         card.colorTheme = CardThemeColor.CardThemeColorType.DefensiveBlue;
                         break;
                     case "empower":
+                        card.colorTheme = CardThemeColor.CardThemeColorType.FirepowerYellow;
+                        break;
+                    case "explosive bullet":
                         card.colorTheme = CardThemeColor.CardThemeColorType.FirepowerYellow;
                         break;
                     case "implode":

--- a/DeckCustomization/RarityUtils.cs
+++ b/DeckCustomization/RarityUtils.cs
@@ -21,6 +21,7 @@ using UnboundLib.Cards;
 using UnityEngine.Events;
 using RarityLib.Utils;
 using System.Text.RegularExpressions;
+using ModdingUtils.Utils;
 
 namespace DeckCustomization
 {
@@ -97,7 +98,7 @@ namespace DeckCustomization
         }
         internal static float Z
         {
-            get { return DeckCustomization.activeCards.Select(c => GetRelativeRarity(c.rarity) * GetRelativeRarity(c.colorTheme) * GetRelativeRarity(c.gameObject.GetComponent<CustomCard>() != null ? c.gameObject.GetComponent<CustomCard>().GetModName().ToLower() : DeckCustomization.defaultCardsName) * RarityLib.Utils.RarityUtils.GetCardRarityModifier(c)).Sum(); }
+            get { return DeckCustomization.activeCards.Select(c => GetRelativeRarity(c.rarity) * GetRelativeRarity(c.colorTheme) * GetRelativeRarity(CardManager.cards.Values.First(c => c.cardInfo == card).category) * RarityLib.Utils.RarityUtils.GetCardRarityModifier(c)).Sum(); }
         }
         internal static float GetRarityAsPerc(string modName)
         {
@@ -129,7 +130,7 @@ namespace DeckCustomization
         }
         internal static float GetRelativeRarity(CardInfo card)
         {
-            return GetRelativeRarity(card.rarity) * GetRelativeRarity(card.colorTheme) * GetRelativeRarity(card.gameObject.GetComponent<CustomCard>() != null ? card.gameObject.GetComponent<CustomCard>().GetModName().ToLower() : DeckCustomization.defaultCardsName) * RarityLib.Utils.RarityUtils.GetCardRarityModifier(card);
+            return GetRelativeRarity(card.rarity) * GetRelativeRarity(card.colorTheme) * GetRelativeRarity(CardManager.cards.Values.First(c => c.cardInfo == card).category) * RarityLib.Utils.RarityUtils.GetCardRarityModifier(card);
         }
         internal static string GetThemeAsString(CardThemeColor.CardThemeColorType theme)
         {


### PR DESCRIPTION
This PR prevents the mod from breaking if unused themes exist, and allows it to more accurately determine what mod a card is from.

It also corrects the themes on DrillAmmo and ExplosiveBullet which were missed by FixCardThemes()